### PR TITLE
Add support for namespaced layers

### DIFF
--- a/test-resources/with-cyclic-dependency-namespaced/.clj-depend/config.edn
+++ b/test-resources/with-cyclic-dependency-namespaced/.clj-depend/config.edn
@@ -1,0 +1,6 @@
+{:source-paths #{"src"}
+ :layers {:controller {:defined-by         #{"sample.controller.foo"}
+                       :namespaced true
+                       :accessed-by-layers #{}}
+          :logic      {:defined-by         ".*\\.logic\\..*"
+                       :accessed-by-layers #{:controller}}}}

--- a/test-resources/with-cyclic-dependency-namespaced/.clj-depend/config.edn
+++ b/test-resources/with-cyclic-dependency-namespaced/.clj-depend/config.edn
@@ -1,6 +1,5 @@
 {:source-paths #{"src"}
- :layers {:controller {:defined-by         #{"sample.controller.foo"}
-                       :namespaced true
+ :layers {:controller {:namespaces         #{sample.controller.foo}
                        :accessed-by-layers #{}}
           :logic      {:defined-by         ".*\\.logic\\..*"
                        :accessed-by-layers #{:controller}}}}

--- a/test-resources/with-cyclic-dependency-namespaced/src/sample/controller/foo.clj
+++ b/test-resources/with-cyclic-dependency-namespaced/src/sample/controller/foo.clj
@@ -1,0 +1,2 @@
+(ns sample.controller.foo
+  (:require [sample.logic.foo :as logic.foo]))

--- a/test-resources/with-cyclic-dependency-namespaced/src/sample/logic/foo.clj
+++ b/test-resources/with-cyclic-dependency-namespaced/src/sample/logic/foo.clj
@@ -1,0 +1,2 @@
+(ns sample.logic.foo
+  (:require [sample.controller.foo :as controller.foo]))

--- a/test-resources/with-violations-namespaced/.clj-depend/config.edn
+++ b/test-resources/with-violations-namespaced/.clj-depend/config.edn
@@ -1,0 +1,6 @@
+{:source-paths #{"src"}
+ :layers {:controller {:defined-by         #{"sample.controller.foo"}
+                       :namespaced true
+                       :accessed-by-layers #{}}
+          :logic      {:defined-by         ".*\\.logic\\..*"
+                       :accessed-by-layers #{:controller}}}}

--- a/test-resources/with-violations-namespaced/.clj-depend/config.edn
+++ b/test-resources/with-violations-namespaced/.clj-depend/config.edn
@@ -1,6 +1,5 @@
 {:source-paths #{"src"}
- :layers {:controller {:defined-by         #{"sample.controller.foo"}
-                       :namespaced true
+ :layers {:controller {:namespaces         #{sample.controller.foo}
                        :accessed-by-layers #{}}
           :logic      {:defined-by         ".*\\.logic\\..*"
                        :accessed-by-layers #{:controller}}}}

--- a/test-resources/with-violations-namespaced/src/sample/controller/foo.clj
+++ b/test-resources/with-violations-namespaced/src/sample/controller/foo.clj
@@ -1,0 +1,1 @@
+(ns sample.controller.foo)

--- a/test-resources/with-violations-namespaced/src/sample/logic/foo.clj
+++ b/test-resources/with-violations-namespaced/src/sample/logic/foo.clj
@@ -1,0 +1,2 @@
+(ns sample.logic.foo
+  (:require [sample.controller.foo :as controller.foo]))

--- a/test-resources/without-violations-namespaced/.clj-depend/config.edn
+++ b/test-resources/without-violations-namespaced/.clj-depend/config.edn
@@ -1,0 +1,6 @@
+{:source-paths #{"src"}
+ :layers {:controller {:defined-by         #{"sample.controller.foo"}
+                       :namespaced true
+                       :accessed-by-layers #{}}
+          :logic      {:defined-by         ".*\\.logic\\..*"
+                       :accessed-by-layers #{:controller}}}}

--- a/test-resources/without-violations-namespaced/.clj-depend/config.edn
+++ b/test-resources/without-violations-namespaced/.clj-depend/config.edn
@@ -1,6 +1,5 @@
 {:source-paths #{"src"}
- :layers {:controller {:defined-by         #{"sample.controller.foo"}
-                       :namespaced true
+ :layers {:controller {:namespaces         #{sample.controller.foo}
                        :accessed-by-layers #{}}
           :logic      {:defined-by         ".*\\.logic\\..*"
                        :accessed-by-layers #{:controller}}}}

--- a/test-resources/without-violations-namespaced/src/sample/controller/foo.clj
+++ b/test-resources/without-violations-namespaced/src/sample/controller/foo.clj
@@ -1,0 +1,2 @@
+(ns sample.controller.foo
+  (:require [sample.logic.foo :as logic.foo]))

--- a/test-resources/without-violations-namespaced/src/sample/logic/bar.clj
+++ b/test-resources/without-violations-namespaced/src/sample/logic/bar.clj
@@ -1,0 +1,2 @@
+(ns without-violations.src.sample.logic.bar
+  (:require [sample.logic.foo :as logic.foo]))

--- a/test-resources/without-violations-namespaced/src/sample/logic/foo.clj
+++ b/test-resources/without-violations-namespaced/src/sample/logic/foo.clj
@@ -1,0 +1,1 @@
+(ns sample.logic.foo)

--- a/test/clj_depend/analyzer_test.clj
+++ b/test/clj_depend/analyzer_test.clj
@@ -24,11 +24,9 @@
                       :c {:defined-by         ".*\\.c\\..*"
                           :accessed-by-layers #{:a :b}}}})
 
-(def config-with-namespaced-layers {:layers {:a {:defined-by         #{"foo.a.bar"}
-                                                 :namespaced true
+(def config-with-namespaced-layers {:layers {:a {:namespaces         #{'foo.a.bar}
                                                  :accessed-by-layers #{}}
-                                             :b {:defined-by         #{"foo.b.bar" "foo.b.baz"}
-                                                 :namespaced true
+                                             :b {:namespaces         #{'foo.b.bar 'foo.b.baz}
                                                  :accessed-by-layers #{:a}}
                                              :c {:defined-by         ".*\\.c\\..*"
                                                  :accessed-by-layers #{:a :b}}}})

--- a/test/clj_depend/api_integration_test.clj
+++ b/test/clj_depend/api_integration_test.clj
@@ -103,3 +103,86 @@
             :message     "Circular dependency between sample.logic.foo and sample.controller.foo"}
            (api/analyze {:project-root (io/file (io/resource "with-cyclic-dependency"))
                          :source-paths #{"src"}})))))
+
+(deftest analyze-namespaced
+
+  (testing "should succeed when there are no violations"
+    (is (= {:result-code 0
+            :message     "No violations found!"}
+           (api/analyze {:project-root (io/file (io/resource "without-violations-namespaced"))}))))
+
+  (testing "should fail when there is at least one violation"
+    (is (= {:result-code 1
+            :message     "\"sample.logic.foo\" should not depends on \"sample.controller.foo\""
+            :violations  [{:namespace            'sample.logic.foo
+                           :dependency-namespace 'sample.controller.foo
+                           :message              "\"sample.logic.foo\" should not depends on \"sample.controller.foo\""}]}
+           (api/analyze {:project-root (io/file (io/resource "with-violations-namespaced"))}))))
+
+  (testing "should fail when given a different configuration as a parameter"
+    (is (= {:result-code 1
+            :message     "\"sample.controller.foo\" should not depends on \"sample.logic.foo\""
+            :violations  [{:namespace            'sample.controller.foo
+                           :dependency-namespace 'sample.logic.foo
+                           :message              "\"sample.controller.foo\" should not depends on \"sample.logic.foo\""}]}
+           (api/analyze {:project-root (io/file (io/resource "without-violations-namespaced"))
+                         :config       {:source-paths #{"src"}
+                                        :layers       {:controller {:defined-by         #{"sample.controller.foo"}
+                                                                    :namespaced true
+                                                                    :accessed-by-layers #{}}
+                                                       :logic      {:defined-by         ".*\\.logic\\..*"
+                                                                    :accessed-by-layers #{}}}}}))))
+
+  (testing "should succeed when given a different configuration as a parameter"
+    (is (= {:result-code 0
+            :message     "No violations found!"}
+           (api/analyze {:project-root (io/file (io/resource "with-violations-namespaced"))
+                         :config       {:source-paths #{"src"}
+                                        :layers       {:controller {:defined-by         #{"sample.controller.foo"}
+                                                                    :namespaced true
+                                                                    :accessed-by-layers #{:logic}}
+                                                       :logic      {:defined-by         ".*\\.logic\\..*"
+                                                                    :accessed-by-layers #{}}}}}))))
+
+  (testing "should succeed when the namespace that has the violation is not included in the analysis"
+    (is (= {:result-code 0
+            :message     "No violations found!"}
+           (api/analyze {:project-root (io/file (io/resource "with-violations-namespaced"))
+                         :namespaces   #{'sample.controller.foo}}))))
+
+  (testing "should fail even when only the namespace that has the violation is included in the analysis."
+    (is (= {:result-code 1
+            :message     "\"sample.logic.foo\" should not depends on \"sample.controller.foo\""
+            :violations  [{:namespace            'sample.logic.foo
+                           :dependency-namespace 'sample.controller.foo
+                           :message              "\"sample.logic.foo\" should not depends on \"sample.controller.foo\""}]}
+           (api/analyze {:project-root (io/file (io/resource "with-violations-namespaced"))
+                         :namespaces   #{'sample.logic.foo}}))))
+
+  (testing "should succeed when the files that has the violation is not included in the analysis"
+    (is (= {:result-code 0
+            :message     "No violations found!"}
+           (api/analyze {:project-root (io/file (io/resource "with-violations-namespaced"))
+                         :files        #{(io/file (io/resource "with-violations-namespaced/src/sample/controller/foo.clj"))}}))))
+
+  (testing "should fail even when only the files that has the violation is included in the analysis."
+    (is (= {:result-code 1
+            :message     "\"sample.logic.foo\" should not depends on \"sample.controller.foo\""
+            :violations  [{:namespace 'sample.logic.foo
+                           :dependency-namespace 'sample.controller.foo
+                           :message "\"sample.logic.foo\" should not depends on \"sample.controller.foo\""}]}
+           (api/analyze {:project-root (io/file (io/resource "with-violations-namespaced"))
+                         :files        #{(io/file (io/resource "with-violations-namespaced/src/sample/logic/foo.clj"))}}))))
+
+  (testing "should succeed when the files that has the violation is included but namespace that has the violation is not included in the analysis"
+    (is (= {:result-code 0
+            :message     "No violations found!"}
+           (api/analyze {:project-root (io/file (io/resource "with-violations-namespaced"))
+                         :files        #{(io/file (io/resource "with-violations-namespaced/src/sample/logic/foo.clj"))}
+                         :namespaces   #{'sample.controller.foo}}))))
+
+  (testing "should fail when a cyclic dependency is identified"
+    (is (= {:result-code 2
+            :message     "Circular dependency between sample.logic.foo and sample.controller.foo"}
+           (api/analyze {:project-root (io/file (io/resource "with-cyclic-dependency-namespaced"))
+                         :source-paths #{"src"}})))))

--- a/test/clj_depend/api_integration_test.clj
+++ b/test/clj_depend/api_integration_test.clj
@@ -127,8 +127,7 @@
                            :message              "\"sample.controller.foo\" should not depends on \"sample.logic.foo\""}]}
            (api/analyze {:project-root (io/file (io/resource "without-violations-namespaced"))
                          :config       {:source-paths #{"src"}
-                                        :layers       {:controller {:defined-by         #{"sample.controller.foo"}
-                                                                    :namespaced true
+                                        :layers       {:controller {:namespaces         #{'sample.controller.foo}
                                                                     :accessed-by-layers #{}}
                                                        :logic      {:defined-by         ".*\\.logic\\..*"
                                                                     :accessed-by-layers #{}}}}}))))
@@ -138,8 +137,7 @@
             :message     "No violations found!"}
            (api/analyze {:project-root (io/file (io/resource "with-violations-namespaced"))
                          :config       {:source-paths #{"src"}
-                                        :layers       {:controller {:defined-by         #{"sample.controller.foo"}
-                                                                    :namespaced true
+                                        :layers       {:controller {:namespaces         #{'sample.controller.foo}
                                                                     :accessed-by-layers #{:logic}}
                                                        :logic      {:defined-by         ".*\\.logic\\..*"
                                                                     :accessed-by-layers #{}}}}}))))


### PR DESCRIPTION
In some cases we have mutiple namespaces as part of a group that should have access to some layer.
Because of this the original approach would be create one layer per file and add this `one-file-layer` on each` :accessed-by-layers` or create a complex regular expression. 

This PR introduces a way for you pass a set of namespaces instead of a regular expression when you want to create a layer of a group of files.

```edn
{:source-paths #{"src"}
 :layers {:controller {:defined-by         #{"sample.controller.foo"}
                                  :namespaced true
                                  :accessed-by-layers #{}}
                :logic      {:defined-by         ".*\\.logic\\..*"
                                :accessed-by-layers #{:controller}}}}
```

When you set the keyword `:namespaced` to true the keyword `:defined-by` now is expected to receive a Set